### PR TITLE
Format publications with flex layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1013,3 +1013,19 @@ section {
     padding-right: 20px 15px;
   }
 }
+/* Publication layout */
+.publication-entry {
+  display: flex;
+  align-items: flex-start;
+  gap: 15px;
+  margin-bottom: 15px;
+}
+.publication-entry:nth-child(even) {
+  flex-direction: row-reverse;
+}
+.publication-image {
+  width: 150px;
+  flex-shrink: 0;
+  margin-bottom: 0;
+}
+

--- a/index.html
+++ b/index.html
@@ -186,6 +186,7 @@
 
       <!-- Article -5 -->
       <article class="post">
+        <div class="publication-entry">
         <ul style="list-style-type: disc; margin-bottom: 3px; padding-left: 0;">
           <li style="font-size: 16px;"><b>SUM: Saliency Unification through Mamba for Visual Attention Modeling</b></li>
         </ul>
@@ -196,12 +197,14 @@
           <p style="font-size: 14px; margin-bottom: 3px;"><i class="fas fa-calendar-alt"></i> <strong>Conference:</strong> <span><b>WACV 2025 | Oral presentation</b></span></p>
           <span style="font-size: 14px; white-space: nowrap;"><a href="https://arhosseini77.github.io/sum_page/" target="_blank"><i class="fas fa-link"></i> Project Page</a></span> | <span style="font-size: 14px; white-space: nowrap;"><a href="https://arxiv.org/abs/2406.17815" target="_blank"><i class="far fa-file-alt"></i> Paper</a></span> | <span style="font-size: 14px; white-space: nowrap;"><a href="https://github.com/Arhosseini77/SUM" target="_blank"><i class="fab fa-github"></i> GitHub</a></span>
         </div>
+        </div>
       </article>
 
       <br>
 
       <!-- Article -5 -->
       <article class="post">
+        <div class="publication-entry">
         <ul style="list-style-type: disc; margin-bottom: 3px; padding-left: 0;">
           <li style="font-size: 16px;"><b>FuseNet: Self-Supervised Dual-Path Network for Medical Image Segmentation</b></li>
         </ul>
@@ -212,12 +215,14 @@
           <p style="font-size: 14px; margin-bottom: 3px;"><i class="fas fa-calendar-alt"></i> <strong>Conference:</strong> <span><b>ISBI 2024</b></span></p>
           <span style="font-size: 14px; white-space: nowrap;"><a href="https://arxiv.org/abs/2311.13069" target="_blank"><i class="far fa-file-alt"></i> Paper</a></span> | <span style="font-size: 14px; white-space: nowrap;"><a href="https://github.com/xmindflow/FuseNet" target="_blank"><i class="fab fa-github"></i> GitHub</a></span>
         </div>
+        </div>
       </article>
 
       <br>
 
       <!-- Article -4 -->
       <article class="post">
+        <div class="publication-entry">
         <ul style="list-style-type: disc; margin-bottom: 3px; padding-left: 0;">
           <li style="font-size: 16px;"><b>INCODE: Implicit Neural Conditioning with Prior Knowledge Embeddings</b></li>
         </ul>
@@ -228,12 +233,14 @@
           <p style="font-size: 14px; margin-bottom: 3px;"><i class="fas fa-calendar-alt"></i> <strong>Conference:</strong> <span><b>IEEE/CVF WACV 2024</b></span></p>
           <span style="font-size: 14px; white-space: nowrap;"><a href="https://xmindflow.github.io/incode" target="_blank"><i class="fas fa-link"></i> Project Page</a></span> | <span style="font-size: 14px; white-space: nowrap;"><a href="https://arxiv.org/abs/2211.07804" target="_blank"><i class="far fa-file-alt"></i> Paper</a></span> | <span style="font-size: 14px; white-space: nowrap;"><a href="https://github.com/xmindflow/INCODE" target="_blank"><i class="fab fa-github"></i> GitHub</a></span>
         </div>
+        </div>
       </article>
 
       <br>
 
       <!-- Article -3 -->
       <article class="post">
+        <div class="publication-entry">
         <ul style="list-style-type: disc; margin-bottom: 3px; padding-left: 0;">
           <li style="font-size: 16px;"><b>Beyond Self-Attention: Deformable Large Kernel Attention for Medical Image Segmentation</b></li>
         </ul>
@@ -244,12 +251,14 @@
           <p style="font-size: 14px; margin-bottom: 3px;"><i class="fas fa-calendar-alt"></i> <strong>Conference:</strong> <span><b>IEEE/CVF WACV 2024</b></span></p>
           <span style="font-size: 14px; white-space: nowrap;"><a href="https://arxiv.org/abs/2309.00121" target="_blank"><i class="far fa-file-alt"></i> Paper</a></span> | <span style="font-size: 14px; white-space: nowrap;"><a href="https://github.com/xmindflow/INCODE" target="_blank"><i class="fab fa-github"></i> GitHub</a></span>
         </div>
+        </div>
       </article>
 
       <br>
 
       <!-- Article -2 -->
       <article class="post">
+        <div class="publication-entry">
         <ul style="list-style-type: disc; margin-bottom: 3px; padding-left: 0;">
           <li style="font-size: 16px;"><b>Laplacian-Former: Overcoming the Limitations of Vision Transformers in Local Texture Detection</b></li>
         </ul>
@@ -260,12 +269,14 @@
           <p style="font-size: 14px; margin-bottom: 3px;"><i class="fas fa-calendar-alt"></i> <strong>Conference:</strong> <span><b>MICCAI 2023</b></span></p>
           <span style="font-size: 14px; white-space: nowrap;"><a href="https://arxiv.org/abs/2309.00108" target="_blank"><i class="far fa-file-alt"></i> Paper</a></span> | <span style="font-size: 14px; white-space: nowrap;"><a href="https://github.com/xmindflow/Laplacian-Former" target="_blank"><i class="fab fa-github"></i> GitHub</a></span>
         </div>
+        </div>
       </article>
   
       <br>
 
       <!-- Article -1 -->
       <article class="post">
+        <div class="publication-entry">
         <ul style="list-style-type: disc; margin-bottom: 3px; padding-left: 0;">
           <li style="font-size: 16px;"><b>Unlocking Fine-Grained Details with Wavelet-based High-Frequency Enhancement in Transformers</b></li>
         </ul>
@@ -276,12 +287,14 @@
           <p style="font-size: 14px; margin-bottom: 3px;"><i class="fas fa-calendar-alt"></i> <strong>Conference:</strong> <span><b>MICCAI 2023 MLMI Workshop</b></span></p>
           <span style="font-size: 14px; white-space: nowrap;"><a href="https://arxiv.org/abs/2308.13442" target="_blank"><i class="far fa-file-alt"></i> Paper</a></span> | <span style="font-size: 14px; white-space: nowrap;"><a href="https://github.com/xmindflow/WaveFormer" target="_blank"><i class="fab fa-github"></i> GitHub</a></span>
         </div>
+        </div>
       </article>
   
       <br>
 
       <!-- Article 0 -->
       <article class="post">
+        <div class="publication-entry">
         <ul style="list-style-type: disc; margin-bottom: 3px; padding-left: 0;">
           <li style="font-size: 16px;"><b>DermoSegDiff: A Boundary-aware Segmentation Diffusion Model for Skin Lesion Delineation</b></li>
         </ul>
@@ -292,12 +305,14 @@
           <p style="font-size: 14px; margin-bottom: 3px;"><i class="fas fa-calendar-alt"></i> <strong>Conference:</strong> <span><b>MICCAI 2023 PRIME Workshop</b></span></p>
           <span style="font-size: 14px; white-space: nowrap;"><a href="https://arxiv.org/abs/2308.02959" target="_blank"><i class="far fa-file-alt"></i> Paper</a></span> | <span style="font-size: 14px; white-space: nowrap;"><a href="https://github.com/xmindflow/DermoSegDiff" target="_blank"><i class="fab fa-github"></i> GitHub</a></span>
         </div>
+        </div>
       </article>
 
       <br>
 
       <!-- Article 00 -->
       <article class="post">
+        <div class="publication-entry">
         <ul style="list-style-type: disc; margin-bottom: 3px; padding-left: 0;">
           <li style="font-size: 16px;"><b>Self-supervised Semantic Segmentation: Consistency over Transformation</b></li>
         </ul>
@@ -308,12 +323,14 @@
           <p style="font-size: 14px; margin-bottom: 3px;"><i class="fas fa-calendar-alt"></i> <strong>Conference:</strong> <span><b>ICCV 2023 CVAMD Workshop</b></span></p>
           <span style="font-size: 14px; white-space: nowrap;"><a href="https://arxiv.org/abs/2309.00143" target="_blank"><i class="far fa-file-alt"></i> Paper</a></span> | <span style="font-size: 14px; white-space: nowrap;"><a href="https://github.com/xmindflow/SSCT" target="_blank"><i class="fab fa-github"></i> GitHub</a></span>
         </div>
+        </div>
       </article>
 
       <br>
 
       <!-- Article 000 -->
       <article class="post">
+        <div class="publication-entry">
         <ul style="list-style-type: disc; margin-bottom: 3px; padding-left: 0;">
           <li style="font-size: 16px;"><b>Implicit neural representation in medical imaging: A comparative survey</b></li>
         </ul>
@@ -324,6 +341,7 @@
           <p style="font-size: 14px; margin-bottom: 3px;"><i class="fas fa-calendar-alt"></i> <strong>Conference:</strong> <span><b>ICCV 2023 CVAMD Workshop</b></span></p>
           <span style="font-size: 14px; white-space: nowrap;"><a href="https://arxiv.org/abs/2307.16142" target="_blank"><i class="far fa-file-alt"></i> Paper</a></span> | <span style="font-size: 14px; white-space: nowrap;"><a href="https://github.com/xmindflow/Awesome-Implicit-Neural-Representations-in-Medical-imaging" target="_blank"><i class="fab fa-github"></i> GitHub</a></span>
         </div>
+        </div>
       </article>
 
       <br>
@@ -331,6 +349,7 @@
 
       <!-- Article 1 -->
       <article class="post">
+        <div class="publication-entry">
         <ul style="list-style-type: disc; margin-bottom: 3px; padding-left: 0;">
           <li style="font-size: 16px;"><b>Diffusion models in medical imaging: A comprehensive survey</b></li>
         </ul>
@@ -341,12 +360,14 @@
           <p style="font-size: 14px; margin-bottom: 3px;"><i class="fas fa-calendar-alt"></i> <strong>Journal:</strong> <span><b>Medical Image Analysis (MedIA)</b></span></p>
           <span style="font-size: 14px; white-space: nowrap;"><a href="https://arxiv.org/abs/2211.07804" target="_blank"><i class="far fa-file-alt"></i> Paper</a></span> | <span style="font-size: 14px; white-space: nowrap;"><a href="https://github.com/amirhossein-kz/Awesome-Diffusion-Models-in-Medical-Imaging" target="_blank"><i class="fab fa-github"></i> GitHub</a></span>
         </div>
+        </div>
       </article>
 
       <br>
 
       <!-- Article -->
       <article class="post">
+        <div class="publication-entry">
         <ul style="list-style-type: disc; margin-bottom: 3px; padding-left: 0;">
           <li style="font-size: 16px;"><b>Advances in Medical Image Analysis with Vision Transformers: A Comprehensive Review</b></li>
         </ul>
@@ -355,12 +376,14 @@
           <p style="font-size: 14px; margin-bottom: 3px;"><i class="fas fa-calendar-alt"></i> <strong>Journal:</strong> <span><b>Medical Image Analysis (MedIA)</b></span></p>
           <span style="font-size: 14px; white-space: nowrap;"><a href="https://arxiv.org/abs/2301.03505" target="_blank"><i class="far fa-file-alt"></i> Paper</a></span> | <span style="font-size: 14px; white-space: nowrap;"><a href="https://github.com/moeinheidari/Awesome-Transformer" target="_blank"><i class="fab fa-github"></i> GitHub</a></span>
         </div>
+        </div>
       </article>
 
       <br>
 
       <!-- Article -->
       <article class="post">
+        <div class="publication-entry">
         <ul style="list-style-type: disc; margin-bottom: 3px; padding-left: 0;">
           <li style="font-size: 16px;"><b>DAE-Former: Dual Attention-guided Efficient Transformer for Medical Image Segmentation</b></li>
         </ul>
@@ -369,12 +392,14 @@
           <p style="font-size: 14px; margin-bottom: 3px;"><i class="fas fa-calendar-alt"></i> <strong>Conference:</strong> <span><b>MICCAI 2023 PRIME Workshop</b></span></p>
           <span style="font-size: 14px; white-space: nowrap;"><a href="https://arxiv.org/abs/2212.13504" target="_blank"><i class="far fa-file-alt"></i> Paper</a></span> | <span style="font-size: 14px; white-space: nowrap;"><a href="https://github.com/mindflow-institue/DAEFormer" target="_blank"><i class="fab fa-github"></i> GitHub</a></span>
         </div>
+        </div>
       </article>
 
       <br>
 
       <!-- Article -->
       <article class="post">
+        <div class="publication-entry">
         <ul style="list-style-type: disc; margin-bottom: 3px; padding-left: 0;">
           <li style="font-size: 16px;"><b>MS-Former: Multi-Scale Self-Guided Transformer for Medical Image Segmentation</b></li>
         </ul>
@@ -383,12 +408,14 @@
           <p style="font-size: 14px; margin-bottom: 3px;"><i class="fas fa-calendar-alt"></i> <strong>Conference:</strong> <span><strong>MIDL 2023 | Oral presentation</strong></span></p>
           <span style="font-size: 14px; white-space: nowrap;"><a href="https://openreview.net/pdf?id=pp2raGSU3Wx" target="_blank"><i class="far fa-file-alt"></i> Paper</a></span> | <span style="font-size: 14px; white-space: nowrap;"><a href="https://github.com/mindflow-institute/MS-Former" target="_blank"><i class="fab fa-github"></i> GitHub</a></span>
         </div>
+        </div>
       </article>
 
       <br>
 
       <!-- Article -->
       <article class="post">
+        <div class="publication-entry">
         <ul style="list-style-type: disc; margin-bottom: 3px; padding-left: 0;">
           <li style="font-size: 16px;"><b>MMCFormer: Missing Modality Compensation Transformer for Brain Tumor Segmentation</b></li>
         </ul>
@@ -397,12 +424,14 @@
           <p style="font-size: 14px; margin-bottom: 3px;"><i class="fas fa-calendar-alt"></i> <strong>Conference:</strong> <span><strong>MIDL 2023 | Oral presentation</strong></span></p>
           <span style="font-size: 14px; white-space: nowrap;"><a href="https://openreview.net/pdf?id=PD0ASSmvlE" target="_blank"><i class="far fa-file-alt"></i> Paper</a></span> | <span style="font-size: 14px; white-space: nowrap;"><a href="https://github.com/mindflow-institue/MMCFormer" target="_blank"><i class="fab fa-github"></i> GitHub</a></span>
         </div>
+        </div>
       </article>
 
       <br>
 
       <!-- Article -->
       <article class="post">
+        <div class="publication-entry">
         <ul style="list-style-type: disc; margin-bottom: 3px; padding-left: 0;">
           <li style="font-size: 16px;"><b>HiFormer: Hierarchical Multi-scale Representations Using Transformers for Medical Image Segmentation</b></li>
         </ul>
@@ -411,12 +440,14 @@
           <p style="font-size: 14px; margin-bottom: 3px;"><i class="fas fa-calendar-alt"></i> <strong>Conference:</strong> <span><b>IEEE/CVF WACV 2023</b></span></p>
           <span style="font-size: 14px; white-space: nowrap;"><a href="https://openaccess.thecvf.com/content/WACV2023/papers/Heidari_HiFormer_Hierarchical_Multi-Scale_Representations_Using_Transformers_for_Medical_Image_Segmentation_WACV_2023_paper.pdf" target="_blank"><i class="far fa-file-alt"></i> Paper</a></span> | <span style="font-size: 14px; white-space: nowrap;"><a href="https://github.com/amirhossein-kz/HiFormer" target="_blank"><i class="fab fa-github"></i> GitHub</a></span>
         </div>
+        </div>
       </article>
 
       <br>
 
       <!-- Article 6 -->
       <article class="post">
+        <div class="publication-entry">
         <ul style="list-style-type: disc; margin-bottom: 3px; padding-left: 0;">
           <li style="font-size: 16px;"><b>An Intelligent Modular Real-Time Vision-Based System for Environment Perception</b></li>
         </ul>
@@ -424,6 +455,7 @@
         <div>
           <p style="font-size: 14px; margin-bottom: 3px;"><i class="fas fa-calendar-alt"></i> <strong>Conference:</strong> <span><b>NeurIPS 2022 Workshop on Machine Learning for Autonomous Driving</b></span></p>
           <span style="font-size: 14px; white-space: nowrap;"><a href="https://ml4ad.github.io/files/papers2022/An%20Intelligent%20Modular%20Real-Time%20Vision-Based%20System%20for%20Environment%20Perception.pdf" target="_blank"><i class="far fa-file-alt"></i> Paper</a></span> | <span style="font-size: 14px; white-space: nowrap;"><a href="https://github.com/Pandas-Team/Autonomous-Vehicle-Environment-Perception" target="_blank"><i class="fab fa-github"></i> GitHub</a></span>
+        </div>
         </div>
       </article>
 


### PR DESCRIPTION
## Summary
- nest each `article.post` body inside a `.publication-entry` wrapper
- apply flexbox layout for `.publication-entry` and `.publication-image`

## Testing
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_686a092967548320ba20121f6aa0dc74